### PR TITLE
fix: clean dist before build to prevent stale artifact bugs

### DIFF
--- a/packages/postext-sandbox/package.json
+++ b/packages/postext-sandbox/package.json
@@ -20,7 +20,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && tsc",
     "dev": "tsc --watch",
     "check-types": "tsc --noEmit",
     "lint": "eslint ."

--- a/packages/postext/package.json
+++ b/packages/postext/package.json
@@ -21,7 +21,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && tsc",
     "dev": "tsc --watch",
     "check-types": "tsc --noEmit",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- Updated the `build` script in both `packages/postext` and `packages/postext-sandbox` from `"tsc"` to `"rm -rf dist && tsc"`
- Prevents stale compiled artifacts from shadowing new output when source files are refactored from single files to directories (e.g., `src/defaults.ts` → `src/defaults/index.ts`)

## Test plan
- [ ] Run `pnpm build` in both packages and verify `dist/` contains only current output
- [ ] Refactor a file to a directory and rebuild — confirm no stale `.js` file remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)